### PR TITLE
Feat/opctelescope abstractions

### DIFF
--- a/src/attributes.zig
+++ b/src/attributes.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const c = @import("c.zig");
+const NodeId = @import("types.zig").NodeId;
+const QualifiedName = @import("types.zig").QualifiedName;
+const NodeClass = @import("types.zig").NodeClass;
+const LocalizedText = @import("localized_text.zig").LocalizedText;
+
+/// Attribute identifier enum for OPC UA attributes
+pub const AttributeId = enum(u32) {
+    node_id = 1,
+    node_class = 2,
+    browse_name = 3,
+    display_name = 4,
+    description = 5,
+    write_mask = 6,
+    user_write_mask = 7,
+    is_abstract = 8,
+    symmetric = 9,
+    inverse_name = 10,
+    contains_no_loops = 11,
+    event_notifier = 12,
+    value = 13,
+    data_type = 14,
+    value_rank = 15,
+    array_dimensions = 16,
+    access_level = 17,
+    user_access_level = 18,
+    minimum_sampling_interval = 19,
+    historizing = 20,
+    executable = 21,
+    user_executable = 22,
+
+    pub fn toC(self: AttributeId) u32 {
+        return @intFromEnum(self);
+    }
+};
+
+/// Result of reading a single attribute
+pub const AttributeValue = union(enum) {
+    node_id: NodeId,
+    node_class: NodeClass,
+    qualified_name: QualifiedName,
+    localized_text: LocalizedText,
+    uint32: u32,
+    uint8: u8,
+    int32: i32,
+    double: f64,
+    boolean: bool,
+    byte_string: []const u8,
+    uint32_array: []const u32,
+    status_error: u32, // Contains status code if read failed
+
+    pub fn deinit(self: AttributeValue, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .node_id => |nid| nid.deinit(allocator),
+            .qualified_name => |*qn| allocator.free(qn.name),
+            .localized_text => |*lt| {
+                allocator.free(lt.locale);
+                allocator.free(lt.text);
+            },
+            .byte_string => |bs| allocator.free(bs),
+            .uint32_array => |arr| allocator.free(arr),
+            else => {},
+        }
+    }
+};
+
+test "AttributeId conversion" {
+    const testing = std.testing;
+    std.testing.refAllDecls(@This());
+
+    try testing.expectEqual(@as(u32, 1), AttributeId.node_id.toC());
+    try testing.expectEqual(@as(u32, 2), AttributeId.node_class.toC());
+    try testing.expectEqual(@as(u32, 13), AttributeId.value.toC());
+}

--- a/src/client.zig
+++ b/src/client.zig
@@ -3,7 +3,12 @@ const c = @import("c.zig");
 const helpers = @import("helpers.zig");
 const ua_error = @import("ua_error.zig");
 const NodeId = @import("types.zig").NodeId;
+const QualifiedName = @import("types.zig").QualifiedName;
+const NodeClass = @import("types.zig").NodeClass;
 const Variant = @import("variant.zig").Variant;
+const DataValue = @import("data_value.zig").DataValue;
+const LocalizedText = @import("localized_text.zig").LocalizedText;
+const String = @import("localized_text.zig").String;
 const ClientConfig = @import("client_config.zig").ClientConfig;
 const browse = @import("browse.zig");
 const BrowseDescription = browse.BrowseDescription;
@@ -14,6 +19,9 @@ const SubscriptionId = subscription.SubscriptionId;
 const MonitoredItemParameters = subscription.MonitoredItemParameters;
 const MonitoredItemId = subscription.MonitoredItemId;
 const DataChangeCallback = subscription.DataChangeCallback;
+const attributes = @import("attributes.zig");
+const AttributeId = attributes.AttributeId;
+const AttributeValue = attributes.AttributeValue;
 
 /// Internal context structure for monitored item callbacks.
 /// This is heap-allocated and managed by the C library's lifecycle.
@@ -532,6 +540,528 @@ pub const Client = struct {
             // Catch-all for unexpected errors (including BADUNEXPECTEDERROR from C code)
             c.UA_STATUSCODE_BADUNEXPECTEDERROR => WriteAttributeError.UnexpectedError,
             else => WriteAttributeError.UnexpectedError,
+        };
+    }
+
+    /// Read a node's value with full DataValue metadata including timestamps.
+    ///
+    /// This function retrieves the current value of a variable node along with its
+    /// source timestamp, server timestamp, and status code. This is useful when you need
+    /// to know when the value was acquired or last updated.
+    ///
+    /// **Memory management:**
+    /// The returned DataValue deep-copies all data from the C library using the provided allocator.
+    /// The caller MUST call `data_value.deinit(allocator)` when done to free the allocated memory.
+    ///
+    /// Example usage:
+    /// ```zig
+    /// const data_value = try client.readDataValue(allocator, node_id);
+    /// defer data_value.deinit(allocator);
+    /// if (data_value.source_timestamp) |ts| {
+    ///     std.debug.print("Value acquired at: {d}\n", .{ts});
+    /// }
+    /// ```
+    ///
+    /// **Errors:**
+    /// See `ReadAttributeError` for the complete list of possible errors.
+    pub fn readDataValue(self: Client, allocator: std.mem.Allocator, node_id: NodeId) ReadAttributeError!DataValue {
+        // SAFETY: c_variant and read_value_id are immediately initialized before any use
+        var read_value_id: c.UA_ReadValueId = undefined;
+        c.UA_ReadValueId_init(&read_value_id);
+        defer c.UA_ReadValueId_clear(&read_value_id);
+
+        // Use internal arena for temporary NodeId conversion
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        defer arena.deinit();
+
+        const c_node_id = node_id.toC(arena.allocator()) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        // Copy NodeId to read_value_id
+        _ = c.UA_NodeId_copy(&c_node_id, &read_value_id.nodeId);
+        read_value_id.attributeId = c.UA_ATTRIBUTEID_VALUE;
+
+        // Create read request
+        var read_request: c.UA_ReadRequest = undefined;
+        c.UA_ReadRequest_init(&read_request);
+        defer c.UA_ReadRequest_clear(&read_request);
+        read_request.nodesToReadSize = 1;
+        read_request.nodesToRead = &read_value_id;
+        read_request.timestampsToReturn = c.UA_TIMESTAMPSTORETURN_BOTH;
+
+        // Execute read
+        var read_response = c.UA_Client_Service_read(self.handle, read_request);
+        defer c.UA_ReadResponse_clear(&read_response);
+
+        // Check service-level status
+        if (read_response.responseHeader.serviceResult != c.UA_STATUSCODE_GOOD) {
+            return mapReadError(read_response.responseHeader.serviceResult);
+        }
+
+        // Check that we got exactly one result
+        if (read_response.resultsSize != 1) {
+            return ReadAttributeError.UnexpectedError;
+        }
+
+        // Check the status of the read result
+        const result = read_response.results[0];
+        if (result.status != c.UA_STATUSCODE_GOOD) {
+            return mapReadError(result.status);
+        }
+
+        // Check that we have a value
+        if (!result.hasValue) {
+            return ReadAttributeError.UnexpectedError;
+        }
+
+        // Convert to Zig DataValue (deep-copies all data)
+        return DataValue.fromC(result, allocator) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+    }
+
+    /// Read multiple node values with timestamps in a single request.
+    ///
+    /// This is more efficient than calling readDataValue() multiple times as it
+    /// batches all reads into a single network request.
+    ///
+    /// **Memory management:**
+    /// The returned slice and all DataValues within it deep-copy data from the C library.
+    /// The caller MUST:
+    /// 1. Call `data_value.deinit(allocator)` on each DataValue in the slice
+    /// 2. Free the slice itself with `allocator.free(slice)`
+    ///
+    /// Example usage:
+    /// ```zig
+    /// const node_ids = [_]NodeId{ node1, node2, node3 };
+    /// const data_values = try client.readDataValues(allocator, &node_ids);
+    /// defer allocator.free(data_values);
+    /// defer for (data_values) |dv| dv.deinit(allocator);
+    /// ```
+    ///
+    /// **Errors:**
+    /// See `ReadAttributeError` for the complete list of possible errors.
+    pub fn readDataValues(
+        self: Client,
+        allocator: std.mem.Allocator,
+        node_ids: []const NodeId,
+    ) ReadAttributeError![]DataValue {
+        if (node_ids.len == 0) {
+            return &[_]DataValue{};
+        }
+
+        // Use internal arena for temporary C conversions
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        defer arena.deinit();
+
+        // Allocate array of UA_ReadValueId
+        const read_value_ids = arena.allocator().alloc(c.UA_ReadValueId, node_ids.len) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        // Initialize all read value IDs
+        for (read_value_ids, 0..) |*rvid, i| {
+            c.UA_ReadValueId_init(rvid);
+            const c_node_id = node_ids[i].toC(arena.allocator()) catch {
+                return ReadAttributeError.OutOfMemory;
+            };
+            _ = c.UA_NodeId_copy(&c_node_id, &rvid.nodeId);
+            rvid.attributeId = c.UA_ATTRIBUTEID_VALUE;
+        }
+
+        // Cleanup read value IDs (arena handles NodeId memory)
+        defer for (read_value_ids) |*rvid| {
+            c.UA_ReadValueId_clear(rvid);
+        };
+
+        // Create read request
+        var read_request: c.UA_ReadRequest = undefined;
+        c.UA_ReadRequest_init(&read_request);
+        defer c.UA_ReadRequest_clear(&read_request);
+        read_request.nodesToReadSize = node_ids.len;
+        read_request.nodesToRead = read_value_ids.ptr;
+        read_request.timestampsToReturn = c.UA_TIMESTAMPSTORETURN_BOTH;
+
+        // Execute read
+        var read_response = c.UA_Client_Service_read(self.handle, read_request);
+        defer c.UA_ReadResponse_clear(&read_response);
+
+        // Check service-level status
+        if (read_response.responseHeader.serviceResult != c.UA_STATUSCODE_GOOD) {
+            return mapReadError(read_response.responseHeader.serviceResult);
+        }
+
+        // Check that we got the expected number of results
+        if (read_response.resultsSize != node_ids.len) {
+            return ReadAttributeError.UnexpectedError;
+        }
+
+        // Allocate result slice
+        const results = allocator.alloc(DataValue, node_ids.len) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+        errdefer allocator.free(results);
+
+        // Convert each result
+        var converted_count: usize = 0;
+        errdefer {
+            // Clean up any successfully converted results if we fail partway through
+            for (results[0..converted_count]) |*dv| {
+                dv.deinit(allocator);
+            }
+        }
+
+        for (read_response.results[0..read_response.resultsSize], 0..) |result, i| {
+            // If individual read failed, propagate the error
+            if (result.status != c.UA_STATUSCODE_GOOD) {
+                allocator.free(results);
+                return mapReadError(result.status);
+            }
+
+            // Check that we have a value
+            if (!result.hasValue) {
+                allocator.free(results);
+                return ReadAttributeError.UnexpectedError;
+            }
+
+            // Convert to Zig DataValue
+            results[i] = DataValue.fromC(result, allocator) catch {
+                allocator.free(results);
+                return ReadAttributeError.OutOfMemory;
+            };
+            converted_count += 1;
+        }
+
+        return results;
+    }
+
+    /// Read multiple attributes from a single node in one request.
+    ///
+    /// This is more efficient than calling individual attribute readers as it
+    /// batches all reads into a single network request.
+    ///
+    /// **Memory management:**
+    /// The returned slice and all AttributeValues within it allocate memory.
+    /// The caller MUST:
+    /// 1. Call `attr_value.deinit(allocator)` on each AttributeValue in the slice
+    /// 2. Free the slice itself with `allocator.free(slice)`
+    ///
+    /// Example usage:
+    /// ```zig
+    /// const attrs = [_]AttributeId{ .node_class, .browse_name, .display_name };
+    /// const values = try client.readAttributes(allocator, node_id, &attrs);
+    /// defer allocator.free(values);
+    /// defer for (values) |v| v.deinit(allocator);
+    /// ```
+    ///
+    /// **Errors:**
+    /// See `ReadAttributeError` for the complete list of possible errors.
+    pub fn readAttributes(
+        self: Client,
+        allocator: std.mem.Allocator,
+        node_id: NodeId,
+        attribute_ids: []const AttributeId,
+    ) ReadAttributeError![]AttributeValue {
+        if (attribute_ids.len == 0) {
+            return &[_]AttributeValue{};
+        }
+
+        // Use internal arena for temporary C conversions
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        defer arena.deinit();
+
+        // Allocate array of UA_ReadValueId
+        const read_value_ids = arena.allocator().alloc(c.UA_ReadValueId, attribute_ids.len) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        const c_node_id = node_id.toC(arena.allocator()) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        // Initialize all read value IDs
+        for (read_value_ids, 0..) |*rvid, i| {
+            c.UA_ReadValueId_init(rvid);
+            _ = c.UA_NodeId_copy(&c_node_id, &rvid.nodeId);
+            rvid.attributeId = attribute_ids[i].toC();
+        }
+
+        // Cleanup read value IDs
+        defer for (read_value_ids) |*rvid| {
+            c.UA_ReadValueId_clear(rvid);
+        };
+
+        // Create read request
+        var read_request: c.UA_ReadRequest = undefined;
+        c.UA_ReadRequest_init(&read_request);
+        defer c.UA_ReadRequest_clear(&read_request);
+        read_request.nodesToReadSize = attribute_ids.len;
+        read_request.nodesToRead = read_value_ids.ptr;
+        read_request.timestampsToReturn = c.UA_TIMESTAMPSTORETURN_NEITHER;
+
+        // Execute read
+        var read_response = c.UA_Client_Service_read(self.handle, read_request);
+        defer c.UA_ReadResponse_clear(&read_response);
+
+        // Check service-level status
+        if (read_response.responseHeader.serviceResult != c.UA_STATUSCODE_GOOD) {
+            return mapReadError(read_response.responseHeader.serviceResult);
+        }
+
+        // Check that we got the expected number of results
+        if (read_response.resultsSize != attribute_ids.len) {
+            return ReadAttributeError.UnexpectedError;
+        }
+
+        // Allocate result slice
+        const results = allocator.alloc(AttributeValue, attribute_ids.len) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+        errdefer allocator.free(results);
+
+        // Convert each result
+        var converted_count: usize = 0;
+        errdefer {
+            for (results[0..converted_count]) |*av| {
+                av.deinit(allocator);
+            }
+        }
+
+        for (read_response.results[0..read_response.resultsSize], 0..) |result, i| {
+            // If individual read failed, store error status
+            if (result.status != c.UA_STATUSCODE_GOOD) {
+                results[i] = .{ .status_error = result.status };
+                converted_count += 1;
+                continue;
+            }
+
+            // Check that we have a value
+            if (!result.hasValue) {
+                results[i] = .{ .status_error = c.UA_STATUSCODE_BADUNEXPECTEDERROR };
+                converted_count += 1;
+                continue;
+            }
+
+            // Convert based on attribute type
+            results[i] = convertAttributeValue(attribute_ids[i], result.value, allocator) catch {
+                allocator.free(results);
+                return ReadAttributeError.OutOfMemory;
+            };
+            converted_count += 1;
+        }
+
+        return results;
+    }
+
+    /// Read node's NodeClass attribute
+    pub fn readNodeClass(self: Client, node_id: NodeId) ReadAttributeError!NodeClass {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        defer arena.deinit();
+
+        const c_node_id = node_id.toC(arena.allocator()) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        var node_class: c.UA_NodeClass = 0;
+        const status = c.UA_Client_readNodeClassAttribute(self.handle, c_node_id, &node_class);
+
+        return switch (status) {
+            c.UA_STATUSCODE_GOOD => NodeClass.fromC(node_class),
+            else => mapReadError(status),
+        };
+    }
+
+    /// Read node's browse name
+    pub fn readBrowseName(
+        self: Client,
+        allocator: std.mem.Allocator,
+        node_id: NodeId,
+    ) ReadAttributeError!QualifiedName {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        defer arena.deinit();
+
+        const c_node_id = node_id.toC(arena.allocator()) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        var browse_name_c: c.UA_QualifiedName = undefined;
+        c.UA_QualifiedName_init(&browse_name_c);
+        defer c.UA_QualifiedName_clear(&browse_name_c);
+
+        const status = c.UA_Client_readBrowseNameAttribute(self.handle, c_node_id, &browse_name_c);
+
+        return switch (status) {
+            c.UA_STATUSCODE_GOOD => blk: {
+                const qn = QualifiedName.fromC(browse_name_c);
+                const name_copy = allocator.dupe(u8, qn.name) catch {
+                    return ReadAttributeError.OutOfMemory;
+                };
+                break :blk QualifiedName{
+                    .namespace_index = qn.namespace_index,
+                    .name = name_copy,
+                };
+            },
+            else => mapReadError(status),
+        };
+    }
+
+    /// Read node's display name
+    pub fn readDisplayName(
+        self: Client,
+        allocator: std.mem.Allocator,
+        node_id: NodeId,
+    ) ReadAttributeError!LocalizedText {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        defer arena.deinit();
+
+        const c_node_id = node_id.toC(arena.allocator()) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        var display_name_c: c.UA_LocalizedText = undefined;
+        c.UA_LocalizedText_init(&display_name_c);
+        defer c.UA_LocalizedText_clear(&display_name_c);
+
+        const status = c.UA_Client_readDisplayNameAttribute(self.handle, c_node_id, &display_name_c);
+
+        return switch (status) {
+            c.UA_STATUSCODE_GOOD => blk: {
+                const lt = LocalizedText.fromC(display_name_c);
+                const locale_copy = allocator.dupe(u8, lt.locale) catch {
+                    return ReadAttributeError.OutOfMemory;
+                };
+                errdefer allocator.free(locale_copy);
+                const text_copy = allocator.dupe(u8, lt.text) catch {
+                    return ReadAttributeError.OutOfMemory;
+                };
+                break :blk LocalizedText{
+                    .locale = locale_copy,
+                    .text = text_copy,
+                };
+            },
+            else => mapReadError(status),
+        };
+    }
+
+    /// Read node's description (may be null)
+    pub fn readDescription(
+        self: Client,
+        allocator: std.mem.Allocator,
+        node_id: NodeId,
+    ) ReadAttributeError!?LocalizedText {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        defer arena.deinit();
+
+        const c_node_id = node_id.toC(arena.allocator()) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        var description_c: c.UA_LocalizedText = undefined;
+        c.UA_LocalizedText_init(&description_c);
+        defer c.UA_LocalizedText_clear(&description_c);
+
+        const status = c.UA_Client_readDescriptionAttribute(self.handle, c_node_id, &description_c);
+
+        return switch (status) {
+            c.UA_STATUSCODE_GOOD => blk: {
+                const lt = LocalizedText.fromC(description_c);
+                if (lt.text.len == 0) break :blk null;
+                const locale_copy = allocator.dupe(u8, lt.locale) catch {
+                    return ReadAttributeError.OutOfMemory;
+                };
+                errdefer allocator.free(locale_copy);
+                const text_copy = allocator.dupe(u8, lt.text) catch {
+                    return ReadAttributeError.OutOfMemory;
+                };
+                break :blk LocalizedText{
+                    .locale = locale_copy,
+                    .text = text_copy,
+                };
+            },
+            c.UA_STATUSCODE_BADATTRIBUTEIDINVALID => null,
+            else => mapReadError(status),
+        };
+    }
+
+    /// Read variable's data type NodeId
+    pub fn readDataType(
+        self: Client,
+        allocator: std.mem.Allocator,
+        node_id: NodeId,
+    ) ReadAttributeError!NodeId {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        defer arena.deinit();
+
+        const c_node_id = node_id.toC(arena.allocator()) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        var data_type_c: c.UA_NodeId = undefined;
+        c.UA_NodeId_init(&data_type_c);
+        defer c.UA_NodeId_clear(&data_type_c);
+
+        const status = c.UA_Client_readDataTypeAttribute(self.handle, c_node_id, &data_type_c);
+
+        return switch (status) {
+            c.UA_STATUSCODE_GOOD => blk: {
+                const dt = NodeId.fromC(data_type_c);
+                // Deep copy the NodeId
+                const result = switch (dt) {
+                    .numeric => |n| NodeId.initNumeric(n.namespace, n.identifier),
+                    .string => |s| blk2: {
+                        const id_copy = allocator.dupe(u8, s.identifier) catch {
+                            return ReadAttributeError.OutOfMemory;
+                        };
+                        break :blk2 NodeId.initString(s.namespace, id_copy);
+                    },
+                    .guid => |g| NodeId.initGuid(g.namespace, g.identifier),
+                    .byte_string => |b| blk2: {
+                        const id_copy = allocator.dupe(u8, b.identifier) catch {
+                            return ReadAttributeError.OutOfMemory;
+                        };
+                        break :blk2 NodeId.initByteString(b.namespace, id_copy);
+                    },
+                };
+                break :blk result;
+            },
+            else => mapReadError(status),
+        };
+    }
+
+    /// Read variable's value rank
+    pub fn readValueRank(self: Client, node_id: NodeId) ReadAttributeError!i32 {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        defer arena.deinit();
+
+        const c_node_id = node_id.toC(arena.allocator()) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        var value_rank: i32 = 0;
+        const status = c.UA_Client_readValueRankAttribute(self.handle, c_node_id, &value_rank);
+
+        return switch (status) {
+            c.UA_STATUSCODE_GOOD => value_rank,
+            else => mapReadError(status),
+        };
+    }
+
+    /// Read variable's access level
+    pub fn readAccessLevel(self: Client, node_id: NodeId) ReadAttributeError!u8 {
+        var arena = std.heap.ArenaAllocator.init(std.heap.c_allocator);
+        defer arena.deinit();
+
+        const c_node_id = node_id.toC(arena.allocator()) catch {
+            return ReadAttributeError.OutOfMemory;
+        };
+
+        var access_level: u8 = 0;
+        const status = c.UA_Client_readAccessLevelAttribute(self.handle, c_node_id, &access_level);
+
+        return switch (status) {
+            c.UA_STATUSCODE_GOOD => access_level,
+            else => mapReadError(status),
         };
     }
 
@@ -1160,6 +1690,38 @@ pub const Client = struct {
         };
     }
 
+    /// Process pending messages and callbacks (for subscriptions).
+    ///
+    /// This should be called periodically when using subscriptions to:
+    /// - Process data change notifications
+    /// - Handle subscription keepalive
+    /// - Invoke registered callbacks
+    ///
+    /// **Parameters:**
+    /// - `timeout_ms`: Maximum time to wait for messages (0 = don't wait)
+    ///
+    /// **Errors:**
+    /// - `BadTimeout` - The operation timed out (not an error if timeout_ms is 0)
+    /// - `BadDisconnect` - The connection was closed
+    /// - `BadConnectionClosed` - The connection is closed
+    /// - `BadInvalidState` - The client is in an invalid state
+    ///
+    /// **Example:**
+    /// ```zig
+    /// // In a loop, process subscription messages
+    /// while (running) {
+    ///     try client.runIterate(100); // Wait up to 100ms
+    /// }
+    /// ```
+    pub fn runIterate(self: Client, timeout_ms: u32) !void {
+        const status = c.UA_Client_run_iterate(self.handle, timeout_ms);
+        return switch (status) {
+            c.UA_STATUSCODE_GOOD => {},
+            c.UA_STATUSCODE_BADTIMEOUT => {}, // Not an error - just no messages
+            else => ua_error.checkStatus(status),
+        };
+    }
+
     /// Create a monitored item with a callback for real-time data change notifications.
     ///
     /// This adds a node to be monitored within a subscription. When the node's value
@@ -1276,6 +1838,184 @@ pub const Client = struct {
         };
     }
 };
+
+/// Convert a UA_Variant to an AttributeValue based on the attribute type
+fn convertAttributeValue(attr_id: AttributeId, variant: c.UA_Variant, allocator: std.mem.Allocator) !AttributeValue {
+    return switch (attr_id) {
+        .node_id => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_NODEID]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            const node_id_ptr: *const c.UA_NodeId = @ptrCast(@alignCast(variant.data));
+            const nid = NodeId.fromC(node_id_ptr.*);
+            // Deep copy the NodeId
+            const result = switch (nid) {
+                .numeric => |n| NodeId.initNumeric(n.namespace, n.identifier),
+                .string => |s| blk2: {
+                    const id_copy = try allocator.dupe(u8, s.identifier);
+                    break :blk2 NodeId.initString(s.namespace, id_copy);
+                },
+                .guid => |g| NodeId.initGuid(g.namespace, g.identifier),
+                .byte_string => |b| blk2: {
+                    const id_copy = try allocator.dupe(u8, b.identifier);
+                    break :blk2 NodeId.initByteString(b.namespace, id_copy);
+                },
+            };
+            break :blk AttributeValue{ .node_id = result };
+        },
+        .node_class => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_INT32]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            const value_ptr: *const i32 = @ptrCast(@alignCast(variant.data));
+            const node_class = NodeClass.fromC(@intCast(value_ptr.*));
+            break :blk AttributeValue{ .node_class = node_class };
+        },
+        .browse_name => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_QUALIFIEDNAME]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            const qn_ptr: *const c.UA_QualifiedName = @ptrCast(@alignCast(variant.data));
+            const qn = QualifiedName.fromC(qn_ptr.*);
+            const name_copy = try allocator.dupe(u8, qn.name);
+            break :blk AttributeValue{
+                .qualified_name = QualifiedName{
+                    .namespace_index = qn.namespace_index,
+                    .name = name_copy,
+                },
+            };
+        },
+        .display_name, .description, .inverse_name => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_LOCALIZEDTEXT]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            const lt_ptr: *const c.UA_LocalizedText = @ptrCast(@alignCast(variant.data));
+            const lt = LocalizedText.fromC(lt_ptr.*);
+            const locale_copy = try allocator.dupe(u8, lt.locale);
+            errdefer allocator.free(locale_copy);
+            const text_copy = try allocator.dupe(u8, lt.text);
+            break :blk AttributeValue{
+                .localized_text = LocalizedText{
+                    .locale = locale_copy,
+                    .text = text_copy,
+                },
+            };
+        },
+        .write_mask, .user_write_mask, .event_notifier => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_UINT32] and variant.type != &c.UA_TYPES[c.UA_TYPES_BYTE]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            if (variant.type == &c.UA_TYPES[c.UA_TYPES_UINT32]) {
+                const value_ptr: *const u32 = @ptrCast(@alignCast(variant.data));
+                break :blk AttributeValue{ .uint32 = value_ptr.* };
+            } else {
+                const value_ptr: *const u8 = @ptrCast(@alignCast(variant.data));
+                break :blk AttributeValue{ .uint8 = value_ptr.* };
+            }
+        },
+        .access_level, .user_access_level => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_BYTE]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            const value_ptr: *const u8 = @ptrCast(@alignCast(variant.data));
+            break :blk AttributeValue{ .uint8 = value_ptr.* };
+        },
+        .value_rank => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_INT32]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            const value_ptr: *const i32 = @ptrCast(@alignCast(variant.data));
+            break :blk AttributeValue{ .int32 = value_ptr.* };
+        },
+        .minimum_sampling_interval => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_DOUBLE]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            const value_ptr: *const f64 = @ptrCast(@alignCast(variant.data));
+            break :blk AttributeValue{ .double = value_ptr.* };
+        },
+        .is_abstract, .symmetric, .contains_no_loops, .historizing, .executable, .user_executable => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_BOOLEAN]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            const value_ptr: *const bool = @ptrCast(@alignCast(variant.data));
+            break :blk AttributeValue{ .boolean = value_ptr.* };
+        },
+        .data_type => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_NODEID]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            const node_id_ptr: *const c.UA_NodeId = @ptrCast(@alignCast(variant.data));
+            const nid = NodeId.fromC(node_id_ptr.*);
+            // Deep copy the NodeId
+            const result = switch (nid) {
+                .numeric => |n| NodeId.initNumeric(n.namespace, n.identifier),
+                .string => |s| blk2: {
+                    const id_copy = try allocator.dupe(u8, s.identifier);
+                    break :blk2 NodeId.initString(s.namespace, id_copy);
+                },
+                .guid => |g| NodeId.initGuid(g.namespace, g.identifier),
+                .byte_string => |b| blk2: {
+                    const id_copy = try allocator.dupe(u8, b.identifier);
+                    break :blk2 NodeId.initByteString(b.namespace, id_copy);
+                },
+            };
+            break :blk AttributeValue{ .node_id = result };
+        },
+        .array_dimensions => blk: {
+            if (variant.type != &c.UA_TYPES[c.UA_TYPES_UINT32]) {
+                break :blk AttributeValue{ .status_error = c.UA_STATUSCODE_BADTYPEMISMATCH };
+            }
+            if (variant.arrayLength == 0) {
+                break :blk AttributeValue{ .uint32_array = &[_]u32{} };
+            }
+            const array_ptr: [*]const u32 = @ptrCast(@alignCast(variant.data));
+            const array_slice = array_ptr[0..variant.arrayLength];
+            const array_copy = try allocator.dupe(u32, array_slice);
+            break :blk AttributeValue{ .uint32_array = array_copy };
+        },
+        else => AttributeValue{ .status_error = c.UA_STATUSCODE_BADATTRIBUTEIDINVALID },
+    };
+}
+
+/// Map OPC UA status codes to ReadAttributeError
+fn mapReadError(status: c.UA_StatusCode) ReadAttributeError {
+    return switch (status) {
+        c.UA_STATUSCODE_GOOD => ReadAttributeError.UnexpectedError, // Should not be called with GOOD
+
+        // Connection/Session errors
+        c.UA_STATUSCODE_BADSERVERNOTCONNECTED => ReadAttributeError.ServerNotConnected,
+        c.UA_STATUSCODE_BADSESSIONCLOSED => ReadAttributeError.SessionClosed,
+        c.UA_STATUSCODE_BADTIMEOUT => ReadAttributeError.Timeout,
+        c.UA_STATUSCODE_BADREQUESTTIMEOUT => ReadAttributeError.Timeout,
+        c.UA_STATUSCODE_BADCOMMUNICATIONERROR => ReadAttributeError.CommunicationError,
+
+        // Node/Attribute errors
+        c.UA_STATUSCODE_BADNODEIDUNKNOWN => ReadAttributeError.NodeIdUnknown,
+        c.UA_STATUSCODE_BADNODEIDINVALID => ReadAttributeError.NodeIdInvalid,
+        c.UA_STATUSCODE_BADATTRIBUTEIDINVALID => ReadAttributeError.AttributeIdInvalid,
+        c.UA_STATUSCODE_BADNOTREADABLE => ReadAttributeError.NotReadable,
+        c.UA_STATUSCODE_BADUSERACCESSDENIED => ReadAttributeError.UserAccessDenied,
+        c.UA_STATUSCODE_BADOBJECTDELETED => ReadAttributeError.ObjectDeleted,
+        c.UA_STATUSCODE_BADNOTFOUND => ReadAttributeError.NotFound,
+
+        // Data errors
+        c.UA_STATUSCODE_BADINDEXRANGEINVALID => ReadAttributeError.IndexRangeInvalid,
+        c.UA_STATUSCODE_BADINDEXRANGENODATA => ReadAttributeError.IndexRangeNoData,
+        c.UA_STATUSCODE_BADDATAENCODINGINVALID => ReadAttributeError.DataEncodingInvalid,
+        c.UA_STATUSCODE_BADDATAENCODINGUNSUPPORTED => ReadAttributeError.DataEncodingUnsupported,
+
+        // System errors
+        c.UA_STATUSCODE_BADOUTOFMEMORY => ReadAttributeError.OutOfMemory,
+        c.UA_STATUSCODE_BADINTERNALERROR => ReadAttributeError.InternalError,
+        c.UA_STATUSCODE_BADSERVICEUNSUPPORTED => ReadAttributeError.ServiceUnsupported,
+        c.UA_STATUSCODE_BADSECURITYCHECKSFAILED => ReadAttributeError.SecurityChecksFailed,
+
+        // Catch-all
+        c.UA_STATUSCODE_BADUNEXPECTEDERROR => ReadAttributeError.UnexpectedError,
+        else => ReadAttributeError.UnexpectedError,
+    };
+}
 
 /// Map OPC UA status codes to BrowseError
 fn mapBrowseError(status: c.UA_StatusCode) BrowseError {

--- a/src/data_value.zig
+++ b/src/data_value.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const c = @import("c.zig");
+const Variant = @import("variant.zig").Variant;
+
+/// DataValue represents an OPC UA data value with metadata including timestamps and status
+pub const DataValue = struct {
+    value: Variant,
+    source_timestamp: ?i64, // Unix timestamp (seconds since 1970)
+    server_timestamp: ?i64, // Unix timestamp (seconds since 1970)
+    status_code: u32,
+
+    /// Free allocated memory
+    pub fn deinit(self: DataValue, allocator: std.mem.Allocator) void {
+        self.value.deinit(allocator);
+    }
+
+    /// Convert OPC UA DateTime (100-nanosecond intervals since Jan 1, 1601) to Unix timestamp (seconds since Jan 1, 1970)
+    /// Returns null if the OPC UA timestamp is 0 (no timestamp)
+    pub fn opcuaDateTimeToUnix(opcua_datetime: i64) ?i64 {
+        if (opcua_datetime == 0) return null;
+        // OPC UA epoch is Jan 1, 1601
+        // Unix epoch is Jan 1, 1970
+        // Difference: 11644473600 seconds
+        const unix_timestamp = @divFloor(opcua_datetime, 10_000_000) - 11644473600;
+        return unix_timestamp;
+    }
+
+    /// Convert from C API representation
+    pub fn fromC(value: c.UA_DataValue, allocator: std.mem.Allocator) !DataValue {
+        const variant = try Variant.fromC(value.value, allocator);
+
+        return .{
+            .value = variant,
+            .source_timestamp = opcuaDateTimeToUnix(value.sourceTimestamp),
+            .server_timestamp = opcuaDateTimeToUnix(value.serverTimestamp),
+            .status_code = value.status,
+        };
+    }
+};
+
+test "DataValue timestamp conversion" {
+    const testing = std.testing;
+    std.testing.refAllDecls(@This());
+
+    // Test zero timestamp (no timestamp)
+    try testing.expectEqual(@as(?i64, null), DataValue.opcuaDateTimeToUnix(0));
+
+    // Test known timestamp: Jan 1, 2000 00:00:00 UTC
+    // Unix timestamp: 946684800
+    // OPC UA timestamp: (946684800 + 11644473600) * 10_000_000 = 125911584000000000
+    const opcua_ts: i64 = 125911584000000000;
+    const unix_ts = DataValue.opcuaDateTimeToUnix(opcua_ts);
+    try testing.expectEqual(@as(?i64, 946684800), unix_ts);
+
+    // Test another known timestamp: Jan 1, 2020 00:00:00 UTC
+    // Unix timestamp: 1577836800
+    // OPC UA timestamp: (1577836800 + 11644473600) * 10_000_000 = 132223104000000000
+    const opcua_ts_2020: i64 = 132223104000000000;
+    const unix_ts_2020 = DataValue.opcuaDateTimeToUnix(opcua_ts_2020);
+    try testing.expectEqual(@as(?i64, 1577836800), unix_ts_2020);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -9,6 +9,9 @@ const variant_module = @import("variant.zig");
 const variable_attributes_module = @import("variable_attributes.zig");
 const object_attributes_module = @import("object_attributes.zig");
 const localized_text_module = @import("localized_text.zig");
+const data_value_module = @import("data_value.zig");
+const attributes_module = @import("attributes.zig");
+const standard_data_types_module = @import("standard_data_types.zig");
 const server_module = @import("server.zig");
 const client_module = @import("client.zig");
 const server_config_module = @import("server_config.zig");
@@ -36,6 +39,7 @@ pub const StandardNodeId = types_module.StandardNodeId;
 pub const ReferenceType = types_module.ReferenceType;
 
 pub const Variant = variant_module.Variant;
+pub const DataValue = data_value_module.DataValue;
 
 pub const VariableAttributes = variable_attributes_module.VariableAttributes;
 pub const AccessLevel = variable_attributes_module.AccessLevel;
@@ -45,6 +49,12 @@ pub const ObjectAttributes = object_attributes_module.ObjectAttributes;
 pub const EventNotifier = object_attributes_module.EventNotifier;
 
 pub const LocalizedText = localized_text_module.LocalizedText;
+
+pub const AttributeId = attributes_module.AttributeId;
+pub const AttributeValue = attributes_module.AttributeValue;
+
+pub const StandardDataType = standard_data_types_module.StandardDataType;
+pub const getDataTypeName = standard_data_types_module.getDataTypeName;
 
 pub const AddNodeError = server_module.AddNodeError;
 pub const NamespaceError = server_module.NamespaceError;
@@ -71,6 +81,8 @@ pub const server = server_module;
 pub const client = client_module;
 pub const browse = browse_module;
 pub const subscription = subscription_module;
+pub const attributes = attributes_module;
+pub const standard_data_types = standard_data_types_module;
 
 test {
     _ = @import("ua_error.zig");
@@ -83,4 +95,7 @@ test {
     _ = @import("client_config.zig");
     _ = @import("browse.zig");
     _ = @import("subscription.zig");
+    _ = @import("data_value.zig");
+    _ = @import("attributes.zig");
+    _ = @import("standard_data_types.zig");
 }

--- a/src/standard_data_types.zig
+++ b/src/standard_data_types.zig
@@ -1,0 +1,119 @@
+const c = @import("c.zig");
+const NodeId = @import("types.zig").NodeId;
+
+/// Standard OPC UA data types with their NodeIds
+pub const StandardDataType = enum(u32) {
+    boolean = 1,
+    sbyte = 2,
+    byte = 3,
+    int16 = 4,
+    uint16 = 5,
+    int32 = 6,
+    uint32 = 7,
+    int64 = 8,
+    uint64 = 9,
+    float = 10,
+    double = 11,
+    string = 12,
+    datetime = 13,
+    guid = 14,
+    bytestring = 15,
+    xml_element = 16,
+    node_id = 17,
+    expanded_node_id = 18,
+    status_code = 19,
+    qualified_name = 20,
+    localized_text = 21,
+    extension_object = 22,
+    data_value = 23,
+    variant = 24,
+    diagnostic_info = 25,
+
+    /// Convert from a NodeId to a StandardDataType (if it matches)
+    pub fn fromNodeId(node_id: NodeId) ?StandardDataType {
+        return switch (node_id) {
+            .numeric => |n| blk: {
+                if (n.namespace != 0) break :blk null;
+                break :blk std.meta.intToEnum(StandardDataType, n.identifier) catch null;
+            },
+            else => null,
+        };
+    }
+
+    /// Convert to a NodeId
+    pub fn toNodeId(self: StandardDataType) NodeId {
+        return NodeId.initNumeric(0, @intFromEnum(self));
+    }
+
+    /// Get the human-readable name of the data type
+    pub fn name(self: StandardDataType) []const u8 {
+        return switch (self) {
+            .boolean => "Boolean",
+            .sbyte => "SByte",
+            .byte => "Byte",
+            .int16 => "Int16",
+            .uint16 => "UInt16",
+            .int32 => "Int32",
+            .uint32 => "UInt32",
+            .int64 => "Int64",
+            .uint64 => "UInt64",
+            .float => "Float",
+            .double => "Double",
+            .string => "String",
+            .datetime => "DateTime",
+            .guid => "Guid",
+            .bytestring => "ByteString",
+            .xml_element => "XmlElement",
+            .node_id => "NodeId",
+            .expanded_node_id => "ExpandedNodeId",
+            .status_code => "StatusCode",
+            .qualified_name => "QualifiedName",
+            .localized_text => "LocalizedText",
+            .extension_object => "ExtensionObject",
+            .data_value => "DataValue",
+            .variant => "Variant",
+            .diagnostic_info => "DiagnosticInfo",
+        };
+    }
+};
+
+/// Get human-readable name for any data type NodeId (including custom types)
+pub fn getDataTypeName(data_type_id: NodeId) []const u8 {
+    if (StandardDataType.fromNodeId(data_type_id)) |std_type| {
+        return std_type.name();
+    }
+    return "Unknown";
+}
+
+const std = @import("std");
+
+test "StandardDataType conversion" {
+    const testing = std.testing;
+    std.testing.refAllDecls(@This());
+
+    // Test toNodeId
+    const double_node_id = StandardDataType.double.toNodeId();
+    try testing.expectEqual(@as(u16, 0), double_node_id.numeric.namespace);
+    try testing.expectEqual(@as(u32, 11), double_node_id.numeric.identifier);
+
+    // Test fromNodeId
+    const maybe_type = StandardDataType.fromNodeId(double_node_id);
+    try testing.expect(maybe_type != null);
+    try testing.expectEqual(StandardDataType.double, maybe_type.?);
+
+    // Test name
+    try testing.expectEqualStrings("Double", StandardDataType.double.name());
+    try testing.expectEqualStrings("Boolean", StandardDataType.boolean.name());
+}
+
+test "StandardDataType getDataTypeName" {
+    const testing = std.testing;
+
+    // Test standard type
+    const double_node_id = NodeId.initNumeric(0, 11);
+    try testing.expectEqualStrings("Double", getDataTypeName(double_node_id));
+
+    // Test custom type
+    const custom_node_id = NodeId.initNumeric(2, 1001);
+    try testing.expectEqualStrings("Unknown", getDataTypeName(custom_node_id));
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -46,6 +46,15 @@ pub const NodeId = union(enum) {
     /// Null/empty NodeId
     pub const null_id = NodeId{ .numeric = .{ .namespace = 0, .identifier = 0 } };
 
+    /// Free allocated memory for string and bytestring NodeIds
+    pub fn deinit(self: NodeId, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .string => |s| allocator.free(s.identifier),
+            .byte_string => |b| allocator.free(b.identifier),
+            .numeric, .guid => {}, // No cleanup needed
+        }
+    }
+
     /// Convert to C API representation
     /// For string/bytestring variants, allocates temporary null-terminated strings.
     /// Caller must call freeToC() with the same allocator to clean up.

--- a/tests/integration/opctelescope_features_test.zig
+++ b/tests/integration/opctelescope_features_test.zig
@@ -1,0 +1,348 @@
+const std = @import("std");
+const testing = std.testing;
+const zopcua = @import("zopcua");
+
+const Server = zopcua.Server;
+const Client = zopcua.Client;
+const NodeId = zopcua.NodeId;
+const QualifiedName = zopcua.QualifiedName;
+const Variant = zopcua.Variant;
+const DataValue = zopcua.DataValue;
+const AttributeId = zopcua.AttributeId;
+const StandardDataType = zopcua.StandardDataType;
+
+test "DataValue read with timestamps" {
+    // Start test server with a variable
+    var server = try Server.init();
+    defer server.deinit();
+
+    _ = try server.addVariableNode(
+        NodeId.initString(1, "temperature"),
+        zopcua.StandardNodeId.objects_folder,
+        zopcua.ReferenceType.organizes,
+        QualifiedName.init(1, "Temperature"),
+        zopcua.StandardNodeId.base_data_variable_type,
+        .{
+            .value = Variant.scalar(f64, 25.5),
+            .access_level = .{ .read = true },
+        },
+    );
+
+    try server.start();
+    defer server.stop() catch {};
+    std.time.sleep(50 * std.time.ns_per_ms);
+
+    // Connect client
+    var client = try Client.init();
+    defer client.deinit();
+    try client.connect("opc.tcp://localhost:4840");
+    defer client.disconnect() catch {};
+
+    // Read with timestamps
+    const data_value = try client.readDataValue(testing.allocator, NodeId.initString(1, "temperature"));
+    defer data_value.deinit(testing.allocator);
+
+    // Verify value
+    try testing.expectEqual(Variant.double, @as(std.meta.Tag(Variant), data_value.value));
+    try testing.expectEqual(@as(f64, 25.5), data_value.value.double);
+
+    // Verify we got timestamps (they should be non-null for a successful read)
+    try testing.expect(data_value.source_timestamp != null or data_value.server_timestamp != null);
+
+    // Verify status is good
+    try testing.expectEqual(@as(u32, 0), data_value.status_code);
+}
+
+test "Batch DataValue reads" {
+    var server = try Server.init();
+    defer server.deinit();
+
+    // Add multiple variables
+    _ = try server.addVariableNode(
+        NodeId.initString(1, "temp1"),
+        zopcua.StandardNodeId.objects_folder,
+        zopcua.ReferenceType.organizes,
+        QualifiedName.init(1, "Temp1"),
+        zopcua.StandardNodeId.base_data_variable_type,
+        .{ .value = Variant.scalar(f64, 20.0) },
+    );
+
+    _ = try server.addVariableNode(
+        NodeId.initString(1, "temp2"),
+        zopcua.StandardNodeId.objects_folder,
+        zopcua.ReferenceType.organizes,
+        QualifiedName.init(1, "Temp2"),
+        zopcua.StandardNodeId.base_data_variable_type,
+        .{ .value = Variant.scalar(f64, 30.0) },
+    );
+
+    _ = try server.addVariableNode(
+        NodeId.initString(1, "temp3"),
+        zopcua.StandardNodeId.objects_folder,
+        zopcua.ReferenceType.organizes,
+        QualifiedName.init(1, "Temp3"),
+        zopcua.StandardNodeId.base_data_variable_type,
+        .{ .value = Variant.scalar(f64, 40.0) },
+    );
+
+    try server.start();
+    defer server.stop() catch {};
+    std.time.sleep(50 * std.time.ns_per_ms);
+
+    var client = try Client.init();
+    defer client.deinit();
+    try client.connect("opc.tcp://localhost:4840");
+    defer client.disconnect() catch {};
+
+    // Batch read all three
+    const node_ids = [_]NodeId{
+        NodeId.initString(1, "temp1"),
+        NodeId.initString(1, "temp2"),
+        NodeId.initString(1, "temp3"),
+    };
+
+    const data_values = try client.readDataValues(testing.allocator, &node_ids);
+    defer testing.allocator.free(data_values);
+    defer for (data_values) |dv| dv.deinit(testing.allocator);
+
+    // Verify we got all three
+    try testing.expectEqual(@as(usize, 3), data_values.len);
+
+    // Verify values
+    try testing.expectEqual(@as(f64, 20.0), data_values[0].value.double);
+    try testing.expectEqual(@as(f64, 30.0), data_values[1].value.double);
+    try testing.expectEqual(@as(f64, 40.0), data_values[2].value.double);
+}
+
+test "Batch attribute reading" {
+    var server = try Server.init();
+    defer server.deinit();
+
+    _ = try server.addVariableNode(
+        NodeId.initString(1, "sensor"),
+        zopcua.StandardNodeId.objects_folder,
+        zopcua.ReferenceType.organizes,
+        QualifiedName.init(1, "MySensor"),
+        zopcua.StandardNodeId.base_data_variable_type,
+        .{
+            .value = Variant.scalar(f64, 42.0),
+            .access_level = .{ .read = true, .write = true },
+        },
+    );
+
+    try server.start();
+    defer server.stop() catch {};
+    std.time.sleep(50 * std.time.ns_per_ms);
+
+    var client = try Client.init();
+    defer client.deinit();
+    try client.connect("opc.tcp://localhost:4840");
+    defer client.disconnect() catch {};
+
+    // Read multiple attributes in one call
+    const attrs = [_]AttributeId{
+        .node_class,
+        .browse_name,
+        .display_name,
+        .access_level,
+    };
+
+    const values = try client.readAttributes(
+        testing.allocator,
+        NodeId.initString(1, "sensor"),
+        &attrs,
+    );
+    defer testing.allocator.free(values);
+    defer for (values) |v| v.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 4), values.len);
+
+    // Verify node class
+    try testing.expectEqual(zopcua.NodeClass.variable, values[0].node_class);
+
+    // Verify browse name
+    try testing.expectEqualStrings("MySensor", values[1].qualified_name.name);
+
+    // Verify display name
+    try testing.expectEqualStrings("MySensor", values[2].localized_text.text);
+
+    // Verify access level (read + write = 3)
+    try testing.expectEqual(@as(u8, 3), values[3].uint8);
+}
+
+test "Individual attribute readers" {
+    var server = try Server.init();
+    defer server.deinit();
+
+    _ = try server.addVariableNode(
+        NodeId.initString(1, "testvar"),
+        zopcua.StandardNodeId.objects_folder,
+        zopcua.ReferenceType.organizes,
+        QualifiedName.init(1, "TestVariable"),
+        zopcua.StandardNodeId.base_data_variable_type,
+        .{
+            .value = Variant.scalar(i32, 123),
+            .access_level = .{ .read = true },
+        },
+    );
+
+    try server.start();
+    defer server.stop() catch {};
+    std.time.sleep(50 * std.time.ns_per_ms);
+
+    var client = try Client.init();
+    defer client.deinit();
+    try client.connect("opc.tcp://localhost:4840");
+    defer client.disconnect() catch {};
+
+    const node = NodeId.initString(1, "testvar");
+
+    // Test individual readers
+    const node_class = try client.readNodeClass(node);
+    try testing.expectEqual(zopcua.NodeClass.variable, node_class);
+
+    const browse_name = try client.readBrowseName(testing.allocator, node);
+    defer testing.allocator.free(browse_name.name);
+    try testing.expectEqualStrings("TestVariable", browse_name.name);
+
+    const display_name = try client.readDisplayName(testing.allocator, node);
+    defer testing.allocator.free(display_name.locale);
+    defer testing.allocator.free(display_name.text);
+    try testing.expectEqualStrings("TestVariable", display_name.text);
+
+    const data_type = try client.readDataType(testing.allocator, node);
+    defer data_type.deinit(testing.allocator);
+    // Should be Int32 (i=6)
+    try testing.expectEqual(@as(u16, 0), data_type.numeric.namespace);
+    try testing.expectEqual(@as(u32, 6), data_type.numeric.identifier);
+
+    const value_rank = try client.readValueRank(node);
+    try testing.expectEqual(@as(i32, -1), value_rank); // Scalar
+
+    const access_level = try client.readAccessLevel(node);
+    try testing.expectEqual(@as(u8, 1), access_level); // Read only
+}
+
+test "StandardDataType helpers" {
+    // Test enum conversions
+    const double_type = StandardDataType.double;
+    try testing.expectEqualStrings("Double", double_type.name());
+
+    const node_id = double_type.toNodeId();
+    try testing.expectEqual(@as(u16, 0), node_id.numeric.namespace);
+    try testing.expectEqual(@as(u32, 11), node_id.numeric.identifier);
+
+    const maybe_type = StandardDataType.fromNodeId(node_id);
+    try testing.expect(maybe_type != null);
+    try testing.expectEqual(StandardDataType.double, maybe_type.?);
+
+    // Test getDataTypeName
+    try testing.expectEqualStrings("Double", zopcua.getDataTypeName(node_id));
+
+    // Test unknown type
+    const custom = NodeId.initNumeric(5, 999);
+    try testing.expectEqualStrings("Unknown", zopcua.getDataTypeName(custom));
+
+    // Test various standard types
+    try testing.expectEqualStrings("Boolean", StandardDataType.boolean.name());
+    try testing.expectEqualStrings("String", StandardDataType.string.name());
+    try testing.expectEqualStrings("Int32", StandardDataType.int32.name());
+    try testing.expectEqualStrings("DateTime", StandardDataType.datetime.name());
+}
+
+test "runIterate for subscriptions" {
+    var server = try Server.init();
+    defer server.deinit();
+
+    _ = try server.addVariableNode(
+        NodeId.initString(1, "counter"),
+        zopcua.StandardNodeId.objects_folder,
+        zopcua.ReferenceType.organizes,
+        QualifiedName.init(1, "Counter"),
+        zopcua.StandardNodeId.base_data_variable_type,
+        .{
+            .value = Variant.scalar(i32, 0),
+            .access_level = .{ .read = true, .write = true },
+        },
+    );
+
+    try server.start();
+    defer server.stop() catch {};
+    std.time.sleep(50 * std.time.ns_per_ms);
+
+    var client = try Client.init();
+    defer client.deinit();
+    try client.connect("opc.tcp://localhost:4840");
+    defer client.disconnect() catch {};
+
+    // Create subscription
+    const sub_id = try client.createSubscription(.{
+        .publishing_interval = 100.0,
+        .priority = 10,
+    });
+    defer client.deleteSubscription(sub_id) catch {};
+
+    const CallbackContext = struct {
+        received: bool = false,
+        value: i32 = 0,
+    };
+
+    var ctx = CallbackContext{};
+
+    const callback = struct {
+        fn onDataChange(
+            userdata: ?*anyopaque,
+            _: zopcua.SubscriptionId,
+            _: zopcua.MonitoredItemId,
+            value: *const Variant,
+        ) void {
+            const c: *CallbackContext = @ptrCast(@alignCast(userdata.?));
+            c.received = true;
+            if (value.* == .int32) {
+                c.value = value.int32;
+            }
+        }
+    }.onDataChange;
+
+    // Create monitored item with callback
+    const mon_id = try client.createMonitoredItemWithCallback(
+        sub_id,
+        .{
+            .node_id = NodeId.initString(1, "counter"),
+            .sampling_interval = 50.0,
+            .queue_size = 10,
+        },
+        callback,
+        &ctx,
+    );
+    defer client.deleteMonitoredItem(sub_id, mon_id) catch {};
+
+    // Process initial notification
+    try client.runIterate(200);
+    std.time.sleep(50 * std.time.ns_per_ms);
+
+    // Write a new value
+    try client.writeValueAttribute(
+        NodeId.initString(1, "counter"),
+        Variant.scalar(i32, 42),
+    );
+
+    // Process notifications using runIterate
+    try client.runIterate(200);
+    std.time.sleep(100 * std.time.ns_per_ms);
+    try client.runIterate(200);
+
+    // Verify callback was invoked
+    try testing.expect(ctx.received);
+    try testing.expectEqual(@as(i32, 42), ctx.value);
+}
+
+test "DataValue timestamp conversion" {
+    // Test the timestamp conversion function directly
+    try testing.expectEqual(@as(?i64, null), DataValue.opcuaDateTimeToUnix(0));
+
+    // Known timestamp: Jan 1, 2000 00:00:00 UTC
+    const opcua_ts: i64 = 125911584000000000;
+    const unix_ts = DataValue.opcuaDateTimeToUnix(opcua_ts);
+    try testing.expectEqual(@as(?i64, 946684800), unix_ts);
+}


### PR DESCRIPTION
Adds Zig wrappers for OPC UA features currently requiring raw C bindings.

  - `readDataValue()` / `readDataValues()` - read values with timestamps
  - `readAttributes()` - batch read node attributes in one request
  - Individual attribute readers: `readNodeClass()`, `readBrowseName()`, `readDisplayName()`, etc.
  - `runIterate()` - process subscription callbacks
  - `StandardDataType` enum and `getDataTypeName()` helper

  All 147 tests passing. No breaking changes.